### PR TITLE
remove of deprected "new Buffer"

### DIFF
--- a/src/lifx/packet.js
+++ b/src/lifx/packet.js
@@ -181,7 +181,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer} packet header buffer
  */
 Packet.headerToBuffer = function(obj) {
-  const buf = new Buffer(36);
+  const buf = Buffer.alloc(36);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/echoRequest.js
+++ b/src/lifx/packets/echoRequest.js
@@ -31,7 +31,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer}     packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/echoResponse.js
+++ b/src/lifx/packets/echoResponse.js
@@ -32,7 +32,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer}     packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/getColorZones.js
+++ b/src/lifx/packets/getColorZones.js
@@ -12,7 +12,7 @@ const Packet = {
  * @return {Buffer} packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/getCountZone.js
+++ b/src/lifx/packets/getCountZone.js
@@ -31,7 +31,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer}     packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/setColor.js
+++ b/src/lifx/packets/setColor.js
@@ -50,7 +50,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer} packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/setColorZones.js
+++ b/src/lifx/packets/setColorZones.js
@@ -59,7 +59,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer} packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/setInfrared.js
+++ b/src/lifx/packets/setInfrared.js
@@ -30,7 +30,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer} packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/setLabel.js
+++ b/src/lifx/packets/setLabel.js
@@ -31,7 +31,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer} packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/setPower.js
+++ b/src/lifx/packets/setPower.js
@@ -34,7 +34,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer} packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/setRgbw.js
+++ b/src/lifx/packets/setRgbw.js
@@ -41,7 +41,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer} packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/setWaveform.js
+++ b/src/lifx/packets/setWaveform.js
@@ -66,7 +66,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer}  packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/stateAmbientLight.js
+++ b/src/lifx/packets/stateAmbientLight.js
@@ -30,7 +30,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer}     packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/stateGroup.js
+++ b/src/lifx/packets/stateGroup.js
@@ -38,7 +38,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer}     packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/stateHostFirmware.js
+++ b/src/lifx/packets/stateHostFirmware.js
@@ -40,7 +40,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer}     packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/stateHostInfo.js
+++ b/src/lifx/packets/stateHostInfo.js
@@ -39,7 +39,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer}     packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/stateInfrared.js
+++ b/src/lifx/packets/stateInfrared.js
@@ -29,7 +29,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer}     packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/stateLabel.js
+++ b/src/lifx/packets/stateLabel.js
@@ -31,7 +31,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer}     packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/stateLight.js
+++ b/src/lifx/packets/stateLight.js
@@ -51,7 +51,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer}     packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/stateLocation.js
+++ b/src/lifx/packets/stateLocation.js
@@ -38,7 +38,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer}     packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/stateMultiZone.js
+++ b/src/lifx/packets/stateMultiZone.js
@@ -51,7 +51,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer} packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer();
+  const buf = Buffer.alloc();
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/stateOwner.js
+++ b/src/lifx/packets/stateOwner.js
@@ -38,7 +38,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer}     packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/statePower.js
+++ b/src/lifx/packets/statePower.js
@@ -29,7 +29,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer}     packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/stateService.js
+++ b/src/lifx/packets/stateService.js
@@ -48,7 +48,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer}     packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/stateTemperature.js
+++ b/src/lifx/packets/stateTemperature.js
@@ -29,7 +29,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer}     packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/stateVersion.js
+++ b/src/lifx/packets/stateVersion.js
@@ -43,7 +43,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer}     packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/stateWifiFirmware.js
+++ b/src/lifx/packets/stateWifiFirmware.js
@@ -40,7 +40,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer}     packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/stateWifiInfo.js
+++ b/src/lifx/packets/stateWifiInfo.js
@@ -39,7 +39,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer}     packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 

--- a/src/lifx/packets/stateZone.js
+++ b/src/lifx/packets/stateZone.js
@@ -51,7 +51,7 @@ Packet.toObject = function(buf) {
  * @return {Buffer} packet
  */
 Packet.toBuffer = function(obj) {
-  const buf = new Buffer(this.size);
+  const buf = Buffer.alloc(this.size);
   buf.fill(0);
   let offset = 0;
 


### PR DESCRIPTION
Please integrated these first in preparation of the TileAPI.
This is only a cleanup of a deprecated api.