### PR TITLE
Mocha runner changed from tdd to bdd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,14 +14,14 @@
       }
     },
     "@babel/generator": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-      "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.0.tgz",
+      "integrity": "sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.4",
+        "@babel/types": "^7.6.0",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       },
@@ -118,39 +118,48 @@
       }
     },
     "@babel/parser": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-      "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
+      "integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-      "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+      "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.4.4",
-        "@babel/types": "^7.4.4"
+        "@babel/parser": "^7.6.0",
+        "@babel/types": "^7.6.0"
       }
     },
     "@babel/traverse": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
-      "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.0.tgz",
+      "integrity": "sha512-93t52SaOBgml/xY74lsmt7xOR4ufYvhb5c5qiM6lu4J/dWGMAfAh6eKw4PjLes6DI6nQgearoxnFJk60YchpvQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.4",
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.6.0",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.4.5",
-        "@babel/types": "^7.4.4",
+        "@babel/parser": "^7.6.0",
+        "@babel/types": "^7.6.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+          "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.0.0"
+          }
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -169,13 +178,13 @@
       }
     },
     "@babel/types": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-      "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
+      "integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
@@ -188,41 +197,32 @@
       }
     },
     "@sinonjs/commons": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
-      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
+      "integrity": "sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
-      },
-      "dependencies": {
-        "type-detect": {
-          "version": "4.0.8",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-          "dev": true
-        }
       }
     },
     "@sinonjs/formatio": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
-      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1",
-        "@sinonjs/samsam": "^3.1.0"
+        "samsam": "1.3.0"
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.1.tgz",
-      "integrity": "sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.0.2",
+        "@sinonjs/commons": "^1.3.0",
         "array-from": "^2.1.1",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.15"
       }
     },
     "@sinonjs/text-encoding": {
@@ -357,9 +357,9 @@
       "optional": true
     },
     "assertion-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "astral-regex": {
@@ -507,17 +507,17 @@
       }
     },
     "babel-eslint": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.1.tgz",
-      "integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
+      "integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/parser": "^7.0.0",
         "@babel/traverse": "^7.0.0",
         "@babel/types": "^7.0.0",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "^1.0.0"
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
       }
     },
     "babel-generator": {
@@ -1224,7 +1224,6 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
       "dev": true,
-      "optional": true,
       "requires": {
         "hoek": "0.9.x"
       }
@@ -1292,17 +1291,17 @@
       "dev": true
     },
     "chai": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
-      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "check-error": "^1.0.1",
-        "deep-eql": "^3.0.0",
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
         "get-func-name": "^2.0.0",
-        "pathval": "^1.0.0",
-        "type-detect": "^4.0.0"
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
       }
     },
     "chalk": {
@@ -1604,17 +1603,21 @@
       }
     },
     "es-abstract": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
+      "integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-symbols": "^1.0.0",
         "is-callable": "^1.1.4",
         "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
+        "object-inspect": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "string.prototype.trimleft": "^2.0.0",
+        "string.prototype.trimright": "^2.0.0"
       }
     },
     "es-to-primitive": {
@@ -1796,16 +1799,6 @@
             "has-flag": "^3.0.0"
           }
         }
-      }
-    },
-    "eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-      "dev": true,
-      "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
       }
     },
     "eslint-utils": {
@@ -2115,15 +2108,6 @@
         "mime": "~1.2.11"
       }
     },
-    "formatio": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-      "dev": true,
-      "requires": {
-        "samsam": "1.x"
-      }
-    },
     "fs-readdir-recursive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
@@ -2156,8 +2140,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2178,14 +2161,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2200,20 +2181,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2330,8 +2308,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2343,7 +2320,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2358,7 +2334,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2366,14 +2341,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2392,7 +2365,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2473,8 +2445,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2486,7 +2457,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2572,8 +2542,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2609,7 +2578,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2629,7 +2597,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2673,14 +2640,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2747,7 +2712,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -2861,8 +2825,7 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
       "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -3042,8 +3005,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
       "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-callable": {
       "version": "1.1.4",
@@ -3085,8 +3047,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -3108,7 +3069,6 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -3322,12 +3282,17 @@
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -3362,9 +3327,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
-      "integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -3534,9 +3499,9 @@
       }
     },
     "mocha": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.1.4.tgz",
-      "integrity": "sha512-PN8CIy4RXsIoxoFJzS4QNnCH4psUCPWc4/rPrst/ecSJJbLBkubMiyGCP2Kj/9YnWbotFqAoeXyXMucj7gwCFg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.0.tgz",
+      "integrity": "sha512-qwfFgY+7EKAAUAdv7VYMZQknI7YJSGesxHyhn6qD52DV8UcSZs5XwCifcZGMVIE4a5fbmhvbotxC0DLQ0oKohQ==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
@@ -3657,28 +3622,32 @@
       "dev": true
     },
     "nise": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.0.tgz",
-      "integrity": "sha512-Z3sfYEkLFzFmL8KY6xnSJLRxwQwYBjOXi/24lb62ZnZiGA0JUzGGTI6TBIgfCSMIDl9Jlu8SRmHNACLTemDHww==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
+      "integrity": "sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/formatio": "^3.2.1",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "lolex": "^4.1.0",
         "path-to-regexp": "^1.7.0"
       },
       "dependencies": {
-        "just-extend": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
-          "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
-          "dev": true
+        "@sinonjs/formatio": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+          "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1",
+            "@sinonjs/samsam": "^3.1.0"
+          }
         },
         "lolex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.1.0.tgz",
-          "integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+          "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
           "dev": true
         }
       }
@@ -3694,9 +3663,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
       }
@@ -3721,7 +3690,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
-      "optional": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -3752,6 +3720,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
       "dev": true
     },
     "object-keys": {
@@ -3896,9 +3870,9 @@
       "dev": true
     },
     "p-limit": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
       "dev": true,
       "requires": {
         "p-try": "^2.0.0"
@@ -3963,6 +3937,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-to-regexp": {
@@ -4093,8 +4073,7 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "string_decoder": {
           "version": "1.0.3",
@@ -4185,15 +4164,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -4246,6 +4223,15 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "resolve": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -4272,12 +4258,28 @@
       }
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "run-async": {
@@ -4357,39 +4359,39 @@
       "dev": true
     },
     "sinon": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.0.2.tgz",
-      "integrity": "sha512-4mUsjHfjrHyPFGDTtNJl0q8cv4VOJGvQykI1r3fnn05ys0sQL9M1Y+DyyGNWLD2PMcoyqjJ/nFDm4K54V1eQOg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
+      "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
       "dev": true,
       "requires": {
+        "@sinonjs/formatio": "^2.0.0",
         "diff": "^3.1.0",
-        "formatio": "1.2.0",
         "lodash.get": "^4.4.2",
-        "lolex": "^2.1.3",
+        "lolex": "^2.2.0",
         "nise": "^1.2.0",
-        "supports-color": "^4.4.0",
-        "type-detect": "^4.0.0"
+        "supports-color": "^5.1.0",
+        "type-detect": "^4.0.5"
       },
       "dependencies": {
         "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "lolex": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.1.3.tgz",
-          "integrity": "sha512-BdHq78SeI+6PAUtl4atDuCt7L6E4fab3mSRtqxm4ywaXe4uP7jZ0TTcFNuU20syUjxZc2l7jFqKVMJ+AX0LnpQ==",
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -4496,6 +4498,26 @@
             "ansi-regex": "^3.0.0"
           }
         }
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {
@@ -4670,9 +4692,9 @@
       }
     },
     "type-detect": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
-      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -8,22 +8,22 @@
   },
   "dependencies": {
     "eventemitter3": "^2.0.3",
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
-    "babel-eslint": "^10.0.1",
+    "babel-eslint": "^10.0.3",
     "babel-preset-env": "^1.7.0",
-    "chai": "^4.1.2",
+    "chai": "^4.2.0",
     "codecov.io": "^0.1.6",
     "eslint": "^5.16.0",
     "istanbul": "^0.4.0",
     "lolex": "^1.6.0",
     "mkdirp": "^0.5.1",
-    "mocha": "^6.1.4",
-    "rimraf": "^2.6.2",
-    "sinon": "^4.0.2"
+    "mocha": "^6.2.0",
+    "rimraf": "^2.7.1",
+    "sinon": "^4.5.0"
   },
   "directories": {
     "test": "test",
@@ -57,9 +57,9 @@
     "lint": "eslint src/ test/ example/ cli.js",
     "lint:fix": "npm run lint -- --fix",
     "pretest": "npm run lint && npm run build",
-    "unittest": "mocha -u tdd -r babelhook --recursive test/unit/ || true",
-    "unittest:bail": "mocha -u tdd -r babelhook --recursive test/unit/ --bail || true",
-    "test": "istanbul cover -root lib/ node_modules/mocha/bin/_mocha -- -u tdd -r babelhook --recursive test/unit/",
+    "unittest": "mocha -u bdd -r babelhook --recursive test/unit/ || true",
+    "unittest:bail": "mocha -u bdd -r babelhook --recursive test/unit/ --bail || true",
+    "test": "istanbul cover -root lib/ node_modules/mocha/bin/_mocha -- -u bdd -r babelhook --recursive test/unit/",
     "report-coverage": "cat ./coverage/coverage.json | node_modules/codecov.io/bin/codecov.io.js"
   }
 }

--- a/src/lifx/utils.js
+++ b/src/lifx/utils.js
@@ -83,6 +83,67 @@ utils.isIpv4Format = function(ip) {
 };
 
 /**
+ * set any val to a number by the given default
+ * @param {any} val given value
+ * @param {Number} def given default
+ * @return {Number} the 16bit number
+ */
+utils.to16Bitnumber = function(val, def) {
+  if (typeof val !== 'number') {
+    if (typeof def === 'number') {
+      val = def;
+    } else {
+      val = 0;
+    }
+  }
+  if (val < 0) {
+    val = (-1 * val) + 0x10000;
+  }
+  return val & 0xffff;
+};
+
+/**
+ * Checks validity of color to be an HSBK Value
+ * This updates HSBK to defaults
+ * @param {Object} color value
+ * @param {Number} color.hue value
+ * @param {Number} color.saturation value
+ * @param {Number} color.brightness value
+ * @param {Number} color.kelvin value
+ * @return {Object} HSBK value
+ */
+utils.toColorHsbk = function(color) {
+  if (typeof color !== 'object') {
+    throw new TypeError('LIFX util toColorHsbk expects colors to be an object');
+  }
+  return {
+    hue: utils.to16Bitnumber(color.hue, 0x8000),
+    saturation: utils.to16Bitnumber(color.saturation, 0x8000),
+    brightness: utils.to16Bitnumber(color.brightness, 0x8000),
+    kelvin: utils.to16Bitnumber(color.kelvin, constants.HSBK_DEFAULT_KELVIN)
+  };
+};
+
+/**
+ * Checks validity of colors array containing HSBK
+ * This updates HSBK values to defaults
+ * @param {array} colors of HSBK values
+ * @param {Number} size if set array has to have size
+ * @return {array} colors array by the given size
+ */
+utils.buildColorsHsbk = function(colors, size) {
+  if (!Array.isArray(colors)) {
+    throw new TypeError('LIFX util buildColorsHsbk expects colors to be an array');
+  }
+  if (typeof size !== 'number') {
+    size = 0;
+  }
+  return (new Array(size))
+    .fill(undefined)
+    .map((_, idx) => this.toColorHsbk(colors[idx] || {}));
+};
+
+/**
  * Converts an RGB Hex string to an object with decimal representations
  * @example rgbHexStringToObject('#FF00FF')
  * @param {String} rgbHexString hex value to parse, with leading #
@@ -125,20 +186,22 @@ utils.rgbHexStringToObject = function(rgbHexString) {
   };
 };
 
+/**
+ * find mininum number in an array
+ * @param {Array} array of numbers
+ * @return {Number} minium of the given array
+ */
 utils.minNumberInArray = function(array) {
-  const sortedCopy = array.slice();
-  sortedCopy.sort(function(a, b) {
-    return a - b;
-  });
-  return sortedCopy[0];
+  return Math.min(...array);
 };
 
+/**
+ * find maxinum number in an array
+ * @param {Array} array of numbers
+ * @return {Number} maxinum of the given array
+ */
 utils.maxNumberInArray = function(array) {
-  const sortedCopy = array.slice();
-  sortedCopy.sort(function(a, b) {
-    return a - b;
-  });
-  return sortedCopy[sortedCopy.length - 1];
+  return Math.max(...array);
 };
 
 /**

--- a/src/lifx/validate.js
+++ b/src/lifx/validate.js
@@ -82,8 +82,8 @@ validate.irBrightness = function(brightness, context) {
  * @param {String} context validation context
  */
 validate.optionalKelvin = function(kelvin, context) {
-  const message = 'LIFX %s expects kelvin to be a number between 2500 and 9000';
   if (kelvin !== undefined) {
+    const message = `LIFX %s expects kelvin to be a number between ${constants.HSBK_MINIMUM_KELVIN} and ${constants.HSBK_MAXIMUM_KELVIN}`;
     if (typeof kelvin !== 'number') {
       throwTypeError(message, context);
     } else if (kelvin < constants.HSBK_MINIMUM_KELVIN || kelvin > constants.HSBK_MAXIMUM_KELVIN) {
@@ -156,6 +156,7 @@ validate.zoneIndex = function(index, context) {
  * Checks validity of an optional light zone index
  * @param {any} index Light zone index to validate
  * @param {String} context validation context
+ * @return {Boolean} const true or an exception
  */
 validate.optionalZoneIndex = function(index, context) {
   const zoneMessage = 'LIFX %s expects zone to be a number between ' +
@@ -167,6 +168,54 @@ validate.optionalZoneIndex = function(index, context) {
       throwRangeError(zoneMessage, context);
     }
   }
+  return true;
+};
+
+/**
+ * test if the given value is an uint value
+ * @param {Number} val the given uint value as number
+ * @param {String} context the string for the error message
+ * @param {Number} range the range of the uint value
+ * @return {Boolean} const true or an exception
+ */
+validate.isUIntRange = function(val, context, range) {
+  if (typeof val !== 'number') {
+    throwTypeError('LIFX %s expects "%s" to be a number', context, val);
+  }
+  if (!(val >= 0 && val <= range)) {
+    throw new RangeError(`LIFX ${context} expects "${val}" to be a number between 0 and ${range}`);
+  }
+  return true;
+};
+
+/**
+ * test if the given value is an uint8 value
+ * @param {Number} val the given uint8 value as number
+ * @param {String} context the string for the error message
+ * @return {Boolean} const true or an exception
+ */
+validate.isUInt8 = function(val, context) {
+  return validate.isUIntRange(val, context, 0xff);
+};
+
+/**
+ * test if the given value is an uint16 value
+ * @param {Number} val the given uint16 value as number
+ * @param {String} context the string for the error message
+ * @return {Boolean} const true or an exception
+ */
+validate.isUInt16 = function(val, context) {
+  return validate.isUIntRange(val, context, 0xffff);
+};
+
+/**
+ * test if the given value is an uint32 value
+ * @param {Number} val the given uint32 value as number
+ * @param {String} context the string for the error message
+ * @return {Boolean} const true or an exception
+ */
+validate.isUInt32 = function(val, context) {
+  return validate.isUIntRange(val, context, 0xffffffff);
 };
 
 /**

--- a/test/unit/client-test.js
+++ b/test/unit/client-test.js
@@ -8,7 +8,7 @@ const assert = require('chai').assert;
 const lolex = require('lolex');
 const sinon = require('sinon');
 
-suite('Client', () => {
+describe('Client', () => {
   let client;
   let clock;
   const getMsgQueueLength = (queueAddress) => {
@@ -35,11 +35,11 @@ suite('Client', () => {
     client.destroy();
   });
 
-  test('not connected by default', () => {
+  it('not connected by default', () => {
     assert.isNull(client.address());
   });
 
-  test('connected after init', (done) => {
+  it('connected after init', (done) => {
     client.init({}, () => {
       assert.isObject(client.address());
       assert.property(client.address(), 'address');
@@ -48,7 +48,7 @@ suite('Client', () => {
     });
   });
 
-  test('accepts init parameters', (done) => {
+  it('accepts init parameters', (done) => {
     client.init({
       address: '127.0.0.1',
       port: 65535,
@@ -77,7 +77,7 @@ suite('Client', () => {
     });
   });
 
-  test('init parameters of wrong types throw exception', () => {
+  it('init parameters of wrong types throw exception', () => {
     assert.throw(() => {
       client.init({port: '57500'});
     }, TypeError);
@@ -155,7 +155,7 @@ suite('Client', () => {
     }, RangeError);
   });
 
-  test('inits with random bind port by default', (done) => {
+  it('inits with random bind port by default', (done) => {
     client.init({
       startDiscovery: false
     }, () => {
@@ -169,7 +169,7 @@ suite('Client', () => {
     });
   });
 
-  test('inits with random source by default', (done) => {
+  it('inits with random source by default', (done) => {
     client.init({
       startDiscovery: false
     }, () => {
@@ -179,7 +179,7 @@ suite('Client', () => {
     });
   });
 
-  test('discovery start and stop', (done) => {
+  it('discovery start and stop', (done) => {
     client.init({
       startDiscovery: false
     }, () => {
@@ -192,7 +192,7 @@ suite('Client', () => {
     });
   });
 
-  test('discovery packet processing', () => {
+  it('discovery packet processing', () => {
     const discoveryMessage = {
       size: 41,
       addressable: true,
@@ -241,7 +241,7 @@ suite('Client', () => {
     assert.equal(currMsgQueCnt, getMsgQueueLength(queueAddress), 'no new messages');
   });
 
-  test('finding bulbs by different parameters', () => {
+  it('finding bulbs by different parameters', () => {
     const bulbs = [];
     let bulb;
 
@@ -332,7 +332,7 @@ suite('Client', () => {
     }, TypeError);
   });
 
-  test('adding packages to the sending queue', (done) => {
+  it('adding packages to the sending queue', (done) => {
     client.init({
       startDiscovery: false
     }, () => {
@@ -354,7 +354,7 @@ suite('Client', () => {
     });
   });
 
-  test('getting all known lights', () => {
+  it('getting all known lights', () => {
     const bulbs = [];
     let bulb;
 
@@ -394,7 +394,7 @@ suite('Client', () => {
     }, TypeError);
   });
 
-  test('changing debugging mode', () => {
+  it('changing debugging mode', () => {
     assert.throw(() => {
       client.setDebug('true');
     }, TypeError);
@@ -408,7 +408,7 @@ suite('Client', () => {
     assert.equal(client.debug, false);
   });
 
-  suite('message handler', () => {
+  describe('message handler', () => {
     beforeEach(() => {
       clock = lolex.install(Date.now());
     });
@@ -417,14 +417,14 @@ suite('Client', () => {
       clock.uninstall();
     });
 
-    test('discovery handler registered by default', () => {
+    it('discovery handler registered by default', () => {
       assert.lengthOf(client.messageHandlers, 3);
       assert.equal(client.messageHandlers[0].type, 'stateService');
       assert.equal(client.messageHandlers[1].type, 'stateLabel');
       assert.equal(client.messageHandlers[2].type, 'stateLight');
     });
 
-    test('adding valid handlers', () => {
+    it('adding valid handlers', () => {
       const prevMsgHandlerCount = client.messageHandlers.length;
       client.addMessageHandler('stateLight', () => {}, 1);
       assert.lengthOf(client.messageHandlers, prevMsgHandlerCount + 1, 'message handler has been added');
@@ -432,7 +432,7 @@ suite('Client', () => {
       assert.equal(client.messageHandlers[prevMsgHandlerCount].timestamp / 1000, Date.now() / 1000, 'timestamp set to now');
     });
 
-    test('adding invalid handlers', () => {
+    it('adding invalid handlers', () => {
       assert.throw(() => {
         client.addMessageHandler('stateLight', () => {}, '1');
       }, TypeError);
@@ -447,7 +447,7 @@ suite('Client', () => {
       }, RangeError);
     });
 
-    test('calling and removing one time handlers after call', (done) => {
+    it('calling and removing one time handlers after call', (done) => {
       let mustBeFalse = false;
       const prevMsgHandlerCount = client.messageHandlers.length;
 
@@ -475,7 +475,7 @@ suite('Client', () => {
       }, {});
     });
 
-    test('keeping permanent handlers after call', (done) => {
+    it('keeping permanent handlers after call', (done) => {
       const prevMsgHandlerCount = client.messageHandlers.length;
       client.addMessageHandler('statePower', (err, msg, rinfo) => {
         assert.isNull(err, 'no error');
@@ -491,7 +491,7 @@ suite('Client', () => {
       assert.lengthOf(client.messageHandlers, prevMsgHandlerCount + 1, 'handler is still present');
     });
 
-    test('calling and removing packets with sequenceNumber, after messageHandlerTimeout', (done) => {
+    it('calling and removing packets with sequenceNumber, after messageHandlerTimeout', (done) => {
       const prevMsgHandlerCount = client.messageHandlers.length;
       const messageHandlerTimeout = 30000; // Our timeout for the test
 
@@ -530,7 +530,7 @@ suite('Client', () => {
     });
   });
 
-  suite('sending process', () => {
+  describe('sending process', () => {
     beforeEach(() => {
       clock = lolex.install(Date.now());
     });
@@ -539,7 +539,7 @@ suite('Client', () => {
       clock.uninstall();
     });
 
-    test('with no meesages in queue', (done) => {
+    it('with no meesages in queue', (done) => {
       const shouldNotBeCalled = () => {
         throw new Error();
       };
@@ -556,7 +556,7 @@ suite('Client', () => {
       });
     });
 
-    test('with new single one way packet in queue', (done) => {
+    it('with new single one way packet in queue', (done) => {
       const packetSendCallback = (msg, rinfo) => {
         if (msg === undefined || rinfo === undefined) {
           throw new Error();
@@ -586,7 +586,7 @@ suite('Client', () => {
       });
     });
 
-    test('with a new request and response packet in queue', (done) => {
+    it('with a new request and response packet in queue', (done) => {
       const packetSendCallback = (msg, rinfo) => {
         if (msg === undefined || rinfo === undefined) {
           throw new Error();
@@ -616,7 +616,7 @@ suite('Client', () => {
       });
     });
 
-    test('with a max retried request and response packet in queue', (done) => {
+    it('with a max retried request and response packet in queue', (done) => {
       const shouldNotBeSendCallback = () => {
         throw new Error();
       };
@@ -650,7 +650,7 @@ suite('Client', () => {
       });
     });
 
-    test('stops discovery after predefined lights found when stopAfterDiscovery is true', (done) => {
+    it('stops discovery after predefined lights found when stopAfterDiscovery is true', (done) => {
       const discoveryMessage = {
         size: 41,
         addressable: true,

--- a/test/unit/light-test.js
+++ b/test/unit/light-test.js
@@ -5,7 +5,7 @@ const Light = require('../../').Light;
 const constant = require('../../').constants;
 const assert = require('chai').assert;
 
-suite('Light', () => {
+describe('Light', () => {
   let client;
   let bulb;
   const getMsgQueueLength = () => {
@@ -43,7 +43,8 @@ suite('Light', () => {
     hue: 0,
     saturation: 0,
     brightness: 0,
-    kelvin: 2500,
+    // the value was changed in constants before
+    kelvin: constant.HSBK_MINIMUM_KELVIN,
     zoneIndex: 0
   };
 
@@ -52,7 +53,7 @@ suite('Light', () => {
     hue: 360,
     saturation: 100,
     brightness: 100,
-    kelvin: 9000,
+    kelvin: constant.HSBK_MAXIMUM_KELVIN,
     zoneIndex: 255
   };
 
@@ -71,11 +72,11 @@ suite('Light', () => {
     client.destroy();
   });
 
-  test('light status \'on\' after instanciation', () => {
+  it('light status \'on\' after instanciation', () => {
     assert.equal(bulb.status, 'on');
   });
 
-  test('turning a light on', () => {
+  it('turning a light on', () => {
     let currMsgQueCnt = getMsgQueueLength();
     let currHandlerCnt = getMsgHandlerLength();
     bulb.on();
@@ -104,7 +105,7 @@ suite('Light', () => {
     currHandlerCnt += 1;
   });
 
-  test('turning a light off', () => {
+  it('turning a light off', () => {
     let currMsgQueCnt = getMsgQueueLength();
     let currHandlerCnt = getMsgHandlerLength();
 
@@ -134,7 +135,7 @@ suite('Light', () => {
     currHandlerCnt += 1;
   });
 
-  test('changing the color of a light', () => {
+  it('changing the color of a light', () => {
     let currMsgQueCnt = getMsgQueueLength();
     let currHandlerCnt = getMsgHandlerLength();
 
@@ -228,7 +229,7 @@ suite('Light', () => {
     currHandlerCnt += 1;
   });
 
-  test('changing the color of a light via rgb integer values', () => {
+  it('changing the color of a light via rgb integer values', () => {
     let currMsgQueCnt = getMsgQueueLength();
     let currHandlerCnt = getMsgHandlerLength();
 
@@ -296,7 +297,7 @@ suite('Light', () => {
     currHandlerCnt += 1;
   });
 
-  test('changing the color of a light via rgb hex values', () => {
+  it('changing the color of a light via rgb hex values', () => {
     let currMsgQueCnt = getMsgQueueLength();
     let currHandlerCnt = getMsgHandlerLength();
 
@@ -329,7 +330,7 @@ suite('Light', () => {
     currHandlerCnt += 1;
   });
 
-  test('changing infrared maximum brightness', () => {
+  it('changing infrared maximum brightness', () => {
     let currMsgQueCnt = getMsgQueueLength();
     let currHandlerCnt = getMsgHandlerLength();
 
@@ -365,7 +366,7 @@ suite('Light', () => {
     currHandlerCnt += 1;
   });
 
-  test('getting light summary', () => {
+  it('getting light summary', () => {
     assert.throw(() => {
       bulb.getState('test');
     }, TypeError);
@@ -376,7 +377,7 @@ suite('Light', () => {
     currHandlerCnt += 1;
   });
 
-  test('getting hardware', () => {
+  it('getting hardware', () => {
     assert.throw(() => {
       bulb.getHardwareVersion('test');
     }, TypeError);
@@ -387,7 +388,7 @@ suite('Light', () => {
     currHandlerCnt += 1;
   });
 
-  test('getting firmware version', () => {
+  it('getting firmware version', () => {
     assert.throw(() => {
       bulb.getFirmwareVersion('test');
     }, TypeError);
@@ -398,7 +399,7 @@ suite('Light', () => {
     currHandlerCnt += 1;
   });
 
-  test('getting firmware info', () => {
+  it('getting firmware info', () => {
     assert.throw(() => {
       bulb.getFirmwareInfo('test');
     }, TypeError);
@@ -409,7 +410,7 @@ suite('Light', () => {
     currHandlerCnt += 1;
   });
 
-  test('getting wifi info', () => {
+  it('getting wifi info', () => {
     assert.throw(() => {
       bulb.getWifiInfo('test');
     }, TypeError);
@@ -420,7 +421,7 @@ suite('Light', () => {
     currHandlerCnt += 1;
   });
 
-  test('getting wifi version', () => {
+  it('getting wifi version', () => {
     assert.throw(() => {
       bulb.getWifiVersion('test');
     }, TypeError);
@@ -431,7 +432,7 @@ suite('Light', () => {
     currHandlerCnt += 1;
   });
 
-  test('getting the label', (done) => {
+  it('getting the label', (done) => {
     assert.throw(() => {
       bulb.getLabel('test');
     }, TypeError, 'expects callback to be a function');
@@ -460,7 +461,7 @@ suite('Light', () => {
     assert.equal(getMsgHandlerLength(), currHandlerCnt, 'does not add a handler if cache availible');
   });
 
-  test('setting the label', () => {
+  it('setting the label', () => {
     let currMsgQueCnt = getMsgQueueLength();
     let currHandlerCnt = getMsgHandlerLength();
     assert.throw(() => {
@@ -500,7 +501,7 @@ suite('Light', () => {
     currHandlerCnt += 1;
   });
 
-  test('getting ambient light', () => {
+  it('getting ambient light', () => {
     assert.throw(() => {
       bulb.getAmbientLight('someValue');
     }, TypeError);
@@ -511,7 +512,7 @@ suite('Light', () => {
     currHandlerCnt += 1;
   });
 
-  test('getting power', () => {
+  it('getting power', () => {
     assert.throw(() => {
       bulb.getPower('someValue');
     }, TypeError);
@@ -522,7 +523,7 @@ suite('Light', () => {
     currHandlerCnt += 1;
   });
 
-  test('getting infrared', () => {
+  it('getting infrared', () => {
     assert.throw(() => {
       bulb.getMaxIR('someValue');
     }, TypeError);
@@ -533,7 +534,7 @@ suite('Light', () => {
     currHandlerCnt += 1;
   });
 
-  test('getting color zones', () => {
+  it('getting color zones', () => {
     // No arguments
     assert.throw(() => {
       bulb.getColorZones();
@@ -565,7 +566,7 @@ suite('Light', () => {
     currHandlerCnt += 1;
   });
 
-  test('changing the color of light zones', () => {
+  it('changing the color of light zones', () => {
     // No arguments or too few arguments
     assert.throw(() => bulb.colorZones(), TypeError);
     assert.throw(() => bulb.colorZones(valid.zoneIndex, valid.zoneIndex), TypeError);

--- a/test/unit/packet-test.js
+++ b/test/unit/packet-test.js
@@ -3,9 +3,9 @@
 const Packet = require('../../').packet;
 const assert = require('chai').assert;
 
-suite('Packet', () => {
-  test('header to object', () => {
-    let msg = new Buffer('240000343e80510800000000000000000000000000000000000000000000000002000000', 'hex');
+describe('Packet', () => {
+  it('header to object', () => {
+    let msg = Buffer.from('240000343e80510800000000000000000000000000000000000000000000000002000000', 'hex');
     let parsed = Packet.headerToObject(msg);
 
     assert.isObject(parsed);
@@ -21,11 +21,11 @@ suite('Packet', () => {
     assert.equal(parsed.site, '');
     assert.equal(parsed.type, 2);
     assert.equal(parsed.sequence, 0);
-    assert.isTrue(parsed.time.equals(new Buffer('0000000000000000', 'hex')));
-    assert.isTrue(parsed.reserved1.equals(new Buffer('0000', 'hex')));
-    assert.isTrue(parsed.reserved2.equals(new Buffer('0000', 'hex')));
+    assert.isTrue(parsed.time.equals(Buffer.from('0000000000000000', 'hex')));
+    assert.isTrue(parsed.reserved1.equals(Buffer.from('0000', 'hex')));
+    assert.isTrue(parsed.reserved2.equals(Buffer.from('0000', 'hex')));
 
-    msg = new Buffer('3200005442524b52d073d5006d7200004c49465856320000c466acd1741bdf13110000001ddb86343fe90100e61701000000', 'hex');
+    msg = Buffer.from('3200005442524b52d073d5006d7200004c49465856320000c466acd1741bdf13110000001ddb86343fe90100e61701000000', 'hex');
     parsed = Packet.headerToObject(msg);
 
     assert.isObject(parsed);
@@ -41,11 +41,11 @@ suite('Packet', () => {
     assert.equal(parsed.site, 'LIFXV2');
     assert.equal(parsed.sequence, 0);
     assert.equal(parsed.type, 17);
-    assert.isTrue(parsed.time.equals(new Buffer('c466acd1741bdf13', 'hex')));
-    assert.isTrue(parsed.reserved1.equals(new Buffer('0000', 'hex')));
-    assert.isTrue(parsed.reserved2.equals(new Buffer('0000', 'hex')));
+    assert.isTrue(parsed.time.equals(Buffer.from('c466acd1741bdf13', 'hex')));
+    assert.isTrue(parsed.reserved1.equals(Buffer.from('0000', 'hex')));
+    assert.isTrue(parsed.reserved2.equals(Buffer.from('0000', 'hex')));
 
-    msg = new Buffer('5c00005442524b52d073d5006d7200004c49465856320000c469ea095c6adf13380000001438456c47c442a9b2603b45972218170000000000000000000000000000000000000000000000000000000000000000406e62fc12f4b913', 'hex');
+    msg = Buffer.from('5c00005442524b52d073d5006d7200004c49465856320000c469ea095c6adf13380000001438456c47c442a9b2603b45972218170000000000000000000000000000000000000000000000000000000000000000406e62fc12f4b913', 'hex');
     parsed = Packet.headerToObject(msg);
 
     assert.isObject(parsed);
@@ -61,11 +61,11 @@ suite('Packet', () => {
     assert.equal(parsed.site, 'LIFXV2');
     assert.equal(parsed.sequence, 0);
     assert.equal(parsed.type, 56);
-    assert.isTrue(parsed.time.equals(new Buffer('c469ea095c6adf13', 'hex')));
-    assert.isTrue(parsed.reserved1.equals(new Buffer('0000', 'hex')));
-    assert.isTrue(parsed.reserved2.equals(new Buffer('0000', 'hex')));
+    assert.isTrue(parsed.time.equals(Buffer.from('c469ea095c6adf13', 'hex')));
+    assert.isTrue(parsed.reserved1.equals(Buffer.from('0000', 'hex')));
+    assert.isTrue(parsed.reserved2.equals(Buffer.from('0000', 'hex')));
 
-    msg = new Buffer('24000014953C1B08D073D5006D7200004C49465856320007000000000000000033000000', 'hex');
+    msg = Buffer.from('24000014953C1B08D073D5006D7200004C49465856320007000000000000000033000000', 'hex');
     parsed = Packet.headerToObject(msg);
 
     assert.isObject(parsed);
@@ -81,15 +81,15 @@ suite('Packet', () => {
     assert.equal(parsed.site, 'LIFXV2');
     assert.equal(parsed.sequence, 7);
     assert.equal(parsed.type, 51);
-    assert.isTrue(parsed.time.equals(new Buffer('0000000000000000', 'hex')));
-    assert.isTrue(parsed.reserved1.equals(new Buffer('0000', 'hex')));
-    assert.isTrue(parsed.reserved2.equals(new Buffer('0000', 'hex')));
+    assert.isTrue(parsed.time.equals(Buffer.from('0000000000000000', 'hex')));
+    assert.isTrue(parsed.reserved1.equals(Buffer.from('0000', 'hex')));
+    assert.isTrue(parsed.reserved2.equals(Buffer.from('0000', 'hex')));
   });
 
-  test('header to buffer', () => {
+  it('header to buffer', () => {
     let expectedResult;
 
-    expectedResult = new Buffer('240000343e80510800000000000000000000000000000000000000000000000002000000', 'hex');
+    expectedResult = Buffer.from('240000343e80510800000000000000000000000000000000000000000000000002000000', 'hex');
     let obj = {
       size: 36,
       tagged: true,
@@ -123,7 +123,7 @@ suite('Packet', () => {
       parsed = Packet.headerToBuffer(obj);
     }, Error);
 
-    expectedResult = new Buffer('5c00005442524b52d073d5006d7200004c49465856320000c469ea095c6adf1338000000', 'hex');
+    expectedResult = Buffer.from('5c00005442524b52d073d5006d7200004c49465856320000c469ea095c6adf1338000000', 'hex');
     obj = {
       size: 92,
       origin: true,
@@ -132,7 +132,7 @@ suite('Packet', () => {
       site: 'LIFXV2',
       sequence: 0,
       type: 'stateOwner',
-      time: new Buffer('c469ea095c6adf13', 'hex'),
+      time: Buffer.from('c469ea095c6adf13', 'hex'),
       owner: '1438456c47c442a9b2603b4597221817',
       label: '',
       updatedAt: '1421435519793000000' // Should not be written
@@ -142,7 +142,7 @@ suite('Packet', () => {
     assert.isTrue(parsed.equals(expectedResult));
   });
 
-  test('package creation', () => {
+  it('package creation', () => {
     let genPacket = Packet.create('getService', {}, '42524b52', 'd073d5006d72');
     assert.isObject(genPacket);
     assert.equal(genPacket.type, 2);
@@ -160,12 +160,12 @@ suite('Packet', () => {
     assert.equal(genPacket.target, 'd073d5006d72');
   });
 
-  test('package to object', () => {
-    let msg = new Buffer('240000343e80510800000000000000000000000000000000000000000000000002000000', 'hex');
+  it('package to object', () => {
+    let msg = Buffer.from('240000343e80510800000000000000000000000000000000000000000000000002000000', 'hex');
     let parsedMsg = Packet.toObject(msg);
     assert.notInstanceOf(parsedMsg, Error);
 
-    msg = new Buffer('240000343e8051080000000000000000000000', 'hex');
+    msg = Buffer.from('240000343e8051080000000000000000000000', 'hex');
     parsedMsg = Packet.toObject(msg);
     assert.instanceOf(parsedMsg, Error);
   });

--- a/test/unit/packets/getService-test.js
+++ b/test/unit/packets/getService-test.js
@@ -3,9 +3,9 @@
 const Packet = require('../../../').packet;
 const assert = require('chai').assert;
 
-suite('Packet getService', () => {
-  suite('create', () => {
-    test('general', () => {
+describe('Packet getService', () => {
+  describe('create', () => {
+    it('general', () => {
       const packet = Packet.create('getService', {}, 'ff2c4807');
       assert.equal(packet.size, 36);
       assert.equal(packet.type, 2);

--- a/test/unit/packets/setColor-test.js
+++ b/test/unit/packets/setColor-test.js
@@ -3,9 +3,9 @@
 const Packet = require('../../../').packet;
 const assert = require('chai').assert;
 
-suite('Packet setColor', () => {
-  suite('create', () => {
-    test('valid colors', () => {
+describe('Packet setColor', () => {
+  describe('create', () => {
+    it('valid colors', () => {
       let packet;
       packet = Packet.create('setColor', {
         hue: 5686,
@@ -36,7 +36,7 @@ suite('Packet setColor', () => {
       assert.equal(packet.type, 102);
     });
 
-    test('invalid colors', () => {
+    it('invalid colors', () => {
       assert.throw(() => {
         const obj = Packet.create('setColor', {
           hue: 0,

--- a/test/unit/packets/setPower-test.js
+++ b/test/unit/packets/setPower-test.js
@@ -3,16 +3,16 @@
 const Packet = require('../../../').packet;
 const assert = require('chai').assert;
 
-suite('Packet setPower', () => {
-  suite('create', () => {
-    test('power off', () => {
+describe('Packet setPower', () => {
+  describe('create', () => {
+    it('power off', () => {
       const packet = Packet.create('setPower', {level: 0}, 'ff2c4807', 'd073d5006d72');
       assert.equal(packet.size, 42);
       assert.equal(packet.level, 0);
       assert.equal(packet.type, 117);
     });
 
-    test('power on over time', () => {
+    it('power on over time', () => {
       const packet = Packet.create('setPower', {level: 65535, duration: 300}, 'ff2c4807', 'd073d5006d72');
       assert.equal(packet.size, 42);
       assert.equal(packet.level, 65535);

--- a/test/unit/utils-test.js
+++ b/test/unit/utils-test.js
@@ -3,8 +3,8 @@
 const utils = require('../../').utils;
 const assert = require('chai').assert;
 
-suite('Utils', () => {
-  test('create a random hex string', () => {
+describe('Utils', () => {
+  it('create a random hex string', () => {
     const test1 = utils.getRandomHexString();
     assert.isString(test1);
     assert.equal(test1, test1.match(/^[0-9A-F]{8}$/)[0]);
@@ -14,7 +14,7 @@ suite('Utils', () => {
     assert.equal(test2, test2.match(/^[0-9A-F]{16}$/)[0]);
   });
 
-  test('getting host ips', () => {
+  it('getting host ips', () => {
     const hostIPs = utils.getHostIPs();
     assert.isArray(hostIPs);
     hostIPs.forEach((ip) => {
@@ -23,7 +23,7 @@ suite('Utils', () => {
     });
   });
 
-  test('validation of IPv4 ips', () => {
+  it('validation of IPv4 ips', () => {
     assert.isTrue(utils.isIpv4Format('255.255.255.255'));
     assert.isTrue(utils.isIpv4Format('98.139.180.149'));
     assert.isTrue(utils.isIpv4Format('0.0.0.0'));
@@ -40,7 +40,7 @@ suite('Utils', () => {
     assert.isFalse(utils.isIpv4Format('98.139.180.149:61500'));
   });
 
-  test('rgb hex string to object with decimal rgb values', () => {
+  it('rgb hex string to object with decimal rgb values', () => {
     assert.throw(() => {
       // No string as argument
       utils.rgbHexStringToObject(111);
@@ -73,7 +73,7 @@ suite('Utils', () => {
     assert.deepEqual(utils.rgbHexStringToObject('#d52664'), {r: 213, g: 38, b: 100});
   });
 
-  test('maximum number in array', () => {
+  it('maximum number in array', () => {
     let values = [24, 1, 18, 254, 255, 21, 0];
     assert.equal(utils.maxNumberInArray(values), 255);
     assert.equal(values[0], 24); // Keep original order
@@ -83,7 +83,7 @@ suite('Utils', () => {
     assert.equal(values[0], 0.25); // Keep original order
   });
 
-  test('minimum number in array', () => {
+  it('minimum number in array', () => {
     let values = [24, 1, 18, 254, 255, 21, 0];
     assert.equal(utils.minNumberInArray(values), 0);
     assert.equal(values[0], 24); // Keep original order
@@ -93,7 +93,7 @@ suite('Utils', () => {
     assert.equal(values[0], 0.25); // Keep original order
   });
 
-  test('rgb to hsb conversion', () => {
+  it('rgb to hsb conversion', () => {
     let rgbObj = {r: 255, g: 255, b: 255};
     assert.deepEqual(utils.rgbToHsb(rgbObj), {h: 0, s: 0, b: 100});
 
@@ -125,7 +125,7 @@ suite('Utils', () => {
     assert.deepEqual(utils.rgbToHsb(rgbObj), {h: 24, s: 43, b: 57});
   });
 
-  test('get hardware info', () => {
+  it('get hardware info', () => {
     const vendorId = 1;
     let hardwareId;
 
@@ -134,9 +134,11 @@ suite('Utils', () => {
       vendorName: 'LIFX',
       productName: 'Original 1000',
       productFeatures: {
+        chain: false,
         color: true,
         infrared: false,
-        multizone: false
+        multizone: false,
+        ['temperature_range']: [2500, 9000]
       }
     });
 
@@ -145,14 +147,94 @@ suite('Utils', () => {
       vendorName: 'LIFX',
       productName: 'White 800 (Low Voltage)',
       productFeatures: {
+        chain: false,
         color: false,
         infrared: false,
-        multizone: false
+        multizone: false,
+        ['temperature_range']: [2700, 6500]
       }
     });
 
     // Product and Vendor IDs start with 1
     assert.equal(utils.getHardwareDetails(0, 1), false);
     assert.equal(utils.getHardwareDetails(1, 0), false);
+  });
+
+  it('to16Bitnumber without default', () => {
+    assert.equal(utils.to16Bitnumber(6), 6);
+    assert.equal(utils.to16Bitnumber(-6), 6);
+    assert.equal(utils.to16Bitnumber('6'), 0);
+  });
+
+  it('to16Bitnumber with default not number', () => {
+    assert.equal(utils.to16Bitnumber(6, 'xx'), 6);
+    assert.equal(utils.to16Bitnumber(-6, 'xx'), 6);
+    assert.equal(utils.to16Bitnumber('6', 'xx'), 0);
+  });
+
+  it('to16Bitnumber with default number', () => {
+    assert.equal(utils.to16Bitnumber(6, 9), 6);
+    assert.equal(utils.to16Bitnumber(-6, 9), 6);
+    assert.equal(utils.to16Bitnumber('6', 9), 9);
+  });
+
+  it('to16Bitnumber with default number wrap', () => {
+    assert.equal(utils.to16Bitnumber(6, 9 + 0xffff), 6);
+    assert.equal(utils.to16Bitnumber(-6, 9 + 0xffff), 6);
+    assert.equal(utils.to16Bitnumber('6', 9 + 0xffff), 8);
+  });
+
+  it('toColorHsbk undefined', () => {
+    assert.throw(() => utils.toColorHsbk(undefined));
+  });
+
+  it('toColorHsbk empty to defaults', () => {
+    assert.deepEqual(utils.toColorHsbk({}), {
+      hue: 32768,
+      saturation: 32768,
+      brightness: 32768,
+      kelvin: 3500
+    });
+  });
+
+  it('toColorHsbk set and passed', () => {
+    assert.deepEqual(utils.toColorHsbk({
+      hue: 4711,
+      saturation: 4712,
+      brightness: 4713,
+      kelvin: 4714
+    }), {
+      hue: 4711,
+      saturation: 4712,
+      brightness: 4713,
+      kelvin: 4714
+    });
+  });
+
+  it('buildColorsHsbk undefined', () => {
+    assert.throw(() => utils.buildColorsHsbk());
+  });
+
+  it('buildColorsHsbk empty', () => {
+    assert.deepEqual(utils.buildColorsHsbk([1, 2]), []);
+  });
+
+  it('buildColorsHsbk def and size', () => {
+    assert.deepEqual(utils.buildColorsHsbk([{
+      hue: 5674
+    }], 2), [
+      {
+        brightness: 32768,
+        hue: 5674,
+        kelvin: 3500,
+        saturation: 32768
+      },
+      {
+        brightness: 32768,
+        hue: 32768,
+        kelvin: 3500,
+        saturation: 32768
+      }
+    ]);
   });
 });

--- a/test/unit/validate-test.js
+++ b/test/unit/validate-test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const validate = require('../../').validate;
+const assert = require('chai').assert;
+
+describe('Validation', () => {
+  it('isUIntRange', () => {
+    try {
+      validate.isUIntRange('666', 'context');
+      assert.fail();
+    } catch (e) {
+      assert.include(e.message, '666');
+      assert.include(e.message, 'context');
+    }
+  });
+
+  it('isUInt8', () => {
+    assert.throw(() => validate.isUInt8(-1));
+    assert.isTrue(validate.isUInt8(0));
+    assert.isTrue(validate.isUInt8(129));
+    assert.isTrue(validate.isUInt8(0xff));
+    assert.throw(() => validate.isUInt8(0x100));
+  });
+
+  it('isUInt16', () => {
+    assert.throw(() => validate.isUInt16(-1));
+    assert.isTrue(validate.isUInt16(0));
+    assert.isTrue(validate.isUInt16(32430));
+    assert.isTrue(validate.isUInt16(0xffff));
+    assert.throw(() => validate.isUInt16(0x10000));
+  });
+
+  it('isUInt32', () => {
+    assert.throw(() => validate.isUInt32(-1));
+    assert.isTrue(validate.isUInt32(0));
+    assert.isTrue(validate.isUInt32(1234949493));
+    assert.isTrue(validate.isUInt32(0xffffffff));
+    assert.throw(() => validate.isUInt32(0x100000000));
+  });
+});


### PR DESCRIPTION
    the update of mocha needs a cleanup of the test runner. The tdd
    test runner was used but tdd does not contain beforeEach. Now the
    bdd test runner is use but suite and test are switched to describe
    and it.
    Introduced some validations and test which are used in the TileApi
    feature.

Version Bump includes package.json and package-lock.json