### PR TITLE
Patch/Bugfix for getInfrared message type

### DIFF
--- a/src/lifx/light.js
+++ b/src/lifx/light.js
@@ -186,6 +186,7 @@ Light.prototype.getMaxIR = function(callback) {
 
   const packetObj = packet.create('getInfrared', {}, this.client.source);
   packetObj.target = this.id;
+  packetObj.resRequired = true;
   const sqnNumber = this.client.send(packetObj);
   this.client.addMessageHandler('stateInfrared', function(err, msg) {
     if (err) {


### PR DESCRIPTION
This patch/bugfix addresses an issue with the Lifx API. For an unknown reason, `getInfrared` (Lifx message type `120`) will not cause the light to send a `stateInfrared` message unless the `res_required` (aka `resRequired`) flag is set to `1`/`true`. This is a special case only for `getInfrared`. All other get message types will respond regardless. An issue has been opened on the Lifx forum: https://community.lifx.com/t/why-is-getinfrared-special/6987

The result of this bug is that IR information is not collected from the light. Additionally, it causes lights with IR capabilities to not be discovered immediately, but instead wait until a timeout occurs, delaying initialization. It also causes the client to continuously poll the light for IR info, for which a response never happens.

This is meant to be a patch only, as it is assumed the Lifx protocol should be updated to send a response even without the `res_required`/`resRequired` flag. If the Lifx protocol is ever changed, this patch is no longer needed.